### PR TITLE
FIX : Set Firefox to launch in kiosk mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN apk --no-cache --update add firefox dbus-x11 ttf-freefont mesa-dri-gallium m
 
 USER user
 
-ENTRYPOINT ["firefox"]
+ENTRYPOINT ["firefox", "--kiosk"]


### PR DESCRIPTION
Modified the Dockerfile to add the "--kiosk" option to the Firefox ENTRYPOINT. This change ensures Firefox starts in kiosk mode by default.